### PR TITLE
feat: Implement full CodeMonkey launcher integration

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,55 +1,50 @@
 function addButton() {
-  // Check if the button already exists to avoid duplicates
   if (document.getElementById('codemonkey-launcher-button')) {
-    return;
+    return; // Button already exists
   }
 
-  // Use a more modern and robust selector for the button group
   const buttonGroup = document.querySelector('.gh-action-menu-group');
 
   if (buttonGroup) {
     const button = document.createElement('button');
     button.type = 'button';
     button.id = 'codemonkey-launcher-button';
-    // Use GitHub's standard classes for buttons in this area
     button.className = 'btn';
     button.innerText = 'Add to CodeMonkey';
     button.style.marginLeft = '8px';
 
-    // Implement the custom protocol handler logic
     button.addEventListener('click', () => {
       const repoUrl = window.location.href;
-      const encodedRepoUrl = encodeURIComponent(repoUrl);
-      const launcherUrl = `codemonkey://add?repo=${encodedRepoUrl}`;
 
-      // Navigate to the custom protocol handler URL
+      const branch = window.prompt("Enter the branch name (e.g., main, master):", "main");
+      if (branch === null) return; // User cancelled
+
+      const folder = window.prompt("Enter the folder path (e.g., docs, dist), or leave empty for root:", "");
+      if (folder === null) return; // User cancelled
+
+      const encodedRepo = encodeURIComponent(repoUrl);
+      const encodedBranch = encodeURIComponent(branch);
+      const encodedFolder = encodeURIComponent(folder);
+
+      const launcherUrl = `codemonkey://add?repo=${encodedRepo}&branch=${encodedBranch}&folder=${encodedFolder}`;
+
       window.location.href = launcherUrl;
     });
 
-    // The buttons in this group are not in an <li>, so just prepend the button
     buttonGroup.prepend(button);
   }
 }
 
-// GitHub uses dynamic navigation, so we need to observe for changes in the DOM.
-// A MutationObserver is the most reliable way to handle this.
-const observer = new MutationObserver((mutations) => {
-  for (const mutation of mutations) {
-    if (mutation.type === 'childList') {
-        // We look for the button group on any significant DOM change.
-        const buttonGroup = document.querySelector('.gh-action-menu-group');
-        if (buttonGroup) {
-            addButton();
-        }
-    }
-  }
+const observer = new MutationObserver(() => {
+  // On any significant DOM change, try to add the button.
+  // The addButton function is idempotent, so this is safe.
+  addButton();
 });
 
-// Start observing the body for child list and subtree changes.
 observer.observe(document.body, {
   childList: true,
-  subtree: true
+  subtree: true,
 });
 
-// Run the function on initial load as well.
+// Also run on initial load
 addButton();

--- a/server.ts
+++ b/server.ts
@@ -1,3 +1,66 @@
+// --- Protocol Handler Logic ---
+// Check if the app was launched with a custom protocol URL
+if (Deno.args.length > 0 && Deno.args[0].startsWith("codemonkey://")) {
+  try {
+    const url = new URL(Deno.args[0]);
+    const repo = url.searchParams.get("repo");
+    const branch = url.searchParams.get("branch");
+    const subdir = url.searchParams.get("folder"); // 'folder' from extension, 'subdir' for API
+
+    if (repo) {
+      console.log(`Adding game from GitHub: ${repo}`);
+
+      // Function to wait for the server to be ready
+      const waitForServer = async (retries = 5, delay = 500) => {
+        for (let i = 0; i < retries; i++) {
+          try {
+            const resp = await fetch("http://localhost:8000/api/games");
+            if (resp.ok) {
+              console.log("Server is up.");
+              return true;
+            }
+          } catch {
+            // Ignore connection errors
+          }
+          console.log(`Server not ready, retrying in ${delay}ms...`);
+          await new Promise(resolve => setTimeout(resolve, delay));
+        }
+        return false;
+      };
+
+      let serverIsUp = await waitForServer(1, 100); // Quick initial check
+
+      if (!serverIsUp) {
+        console.log("Server not detected. Launching in background...");
+        new Deno.Command(Deno.execPath(), {
+          args: ["run", "-A", "server.ts"],
+        }).spawn();
+        serverIsUp = await waitForServer(5, 1000); // Wait longer after launch
+      }
+
+      if (!serverIsUp) {
+        throw new Error("Server did not start in time. Cannot add game.");
+      }
+
+      const addResp = await fetch("http://localhost:8000/api/add-game/from-github", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repo, branch, subdir }),
+      });
+
+      if (addResp.ok) {
+        console.log("Successfully added game via API.");
+      } else {
+        console.error("Failed to add game via API:", await addResp.text());
+      }
+    }
+  } catch (error) {
+    console.error("Failed to handle protocol URL:", error);
+  }
+  Deno.exit();
+}
+// --- End Protocol Handler Logic ---
+
 // Deno web app server for launching Phaser/Kaplay games
 // Serves static frontend and manages game library under ./games
 


### PR DESCRIPTION
This commit introduces a complete feature set for integrating a Chrome extension with the Deno-based CodeMonkey Games Launcher.

The Chrome extension adds a button to GitHub repository pages. When clicked, it prompts the user for a branch and folder, then constructs and launches a `codemonkey://add` custom protocol URL with the repository details.

The Deno application (`server.ts`) is updated to handle these `codemonkey://` URLs. When launched with such a URL, it now:
1.  Parses the repository, branch, and folder from the URL.
2.  Robustly checks if the main server is running, launching it in the background if necessary.
3.  Calls its own `/api/add-game/from-github` endpoint to process the request.
4.  Exits after dispatching the request.

This provides a seamless workflow for adding games to the launcher directly from GitHub.