### PR TITLE
Fix controller layout options being cut off

### DIFF
--- a/static/gamepad-support.js
+++ b/static/gamepad-support.js
@@ -1987,6 +1987,7 @@ const configuratorCSS = `
   display: flex;
   flex-direction: column;
   gap: 20px;
+  overflow-y: auto;
 }
 
 .mapping-info h3 {


### PR DESCRIPTION
The controller layout sidebar was not scrollable, causing some options to be inaccessible on smaller screens.

This change adds `overflow-y: auto` to the `.configurator-sidebar` CSS class, making it scrollable when its content exceeds the available height.