### PR TITLE
Fix: correct import path for utils.ts in routes/[...path].ts

### DIFF
--- a/routes/[...path].ts
+++ b/routes/[...path].ts
@@ -1,7 +1,7 @@
 import { Handlers } from "$fresh/server.ts";
 import { contentType } from "https://deno.land/std@0.224.0/media_types/mod.ts";
 import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
-import { GAMES_DIR, ROOT } from "../../lib/utils.ts";
+import { GAMES_DIR, ROOT } from "../lib/utils.ts";
 
 const injections = {
   css: `\n<style>


### PR DESCRIPTION
The import path for `lib/utils.ts` in `routes/[...path].ts` was incorrect. It was `../../lib/utils.ts`, which pointed outside the project root. This has been corrected to `../lib/utils.ts`.

I was unable to verify this fix by running the development server due to limitations in the execution environment that prevented me from installing the Deno runtime.