### PR TITLE
fix: pin Deno version to fix stuck build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v1.42.0
 
       - name: Build step
         run: "deno task build"


### PR DESCRIPTION
The GitHub Actions workflow was getting stuck during the `deno task build` step. This was caused by using a floating Deno version `v2.x`, which likely installed a version of Deno incompatible with the project's dependencies, specifically `fresh@1.6.8`.

This change pins the Deno version to `v1.42.0`, which is known to be compatible with the version of the Deno standard library used by `fresh@1.6.8`, thus resolving the build issue.