### PR TITLE
chore: add diagnostic step to check Deno version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           deno-version: v1.42.0
 
+      - name: Check Deno version
+        run: deno --version
+
       - name: Build step
         run: "deno task build"
 


### PR DESCRIPTION
This change adds a step to the GitHub Actions workflow to print the Deno version being used. This is a diagnostic step to help understand why the build is failing, even after pinning the Deno version.

The `deno.lock` file has also been removed to be regenerated by the CI.