### PR TITLE
Add more diagnostic steps to the workflow.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,13 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:
-
           deno-version: "1.42.0"
+
+      - name: Check Deno version
+        run: deno --version
+
+      - name: Inspect dependency tree
+        run: deno info --json --no-lock main.ts
 
       - name: Build step
         run: "deno task build"


### PR DESCRIPTION
This change adds two steps to the GitHub Actions workflow:
1.  `deno --version` to confirm the Deno version being used.
2.  `deno info --json --no-lock main.ts` to inspect the full dependency tree.

This is to help diagnose why the build is failing.