### PR TITLE
Fix(main): Resolve webview import and add missing dependency

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -41,6 +41,7 @@
     "@preact/signals": "https://esm.sh/*@preact/signals@2.3.1",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.12.1",
     "vite": "npm:vite@5.4.20",
-    "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^1.0.4"
+    "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^1.0.4",
+    "@webview/webview": "jsr:@webview/webview@^0.9.0"
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -21,7 +21,8 @@ const RUNTIME_CONFIG = JSON.stringify({
     "tailwindcss/": "npm:/tailwindcss@3.4.1/",
     "tailwindcss/plugin": "npm:/tailwindcss@3.4.1/plugin.js",
     "vite": "npm:vite@5.4.20",
-    "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^1.0.4"
+    "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^1.0.4",
+    "@webview/webview": "jsr:@webview/webview@^0.9.0"
   },
   compilerOptions: {
     jsx: "react-jsx",


### PR DESCRIPTION
The application was failing to start due to two issues:
1. The `@webview/webview` import was missing from the fallback `RUNTIME_CONFIG` in `main.ts`, causing an import resolution error in environments where `deno.jsonc` was not available.
2. The `libwebkitgtk-6.0.so.4` shared library, a runtime dependency for the webview, was not present in the environment.

This commit addresses both issues by:
- Adding the `@webview/webview` import to the `RUNTIME_CONFIG` in `main.ts` to ensure the application can start even without `deno.jsonc`.
- The missing system dependency `libwebkitgtk-6.0-4` was installed in the environment to resolve the runtime error.
- Removed extraneous `install.sh` and `app.log` files from the repository.