### PR TITLE
feat: Add deno build task for Deno deploy

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,8 @@
 {
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/,islands/ main.ts",
-    "preview": "deno serve -A _fresh/server.js",
+    "dev": "deno run -A --watch=static/,routes/,islands/ main.ts",
+    "build": "deno run -A main.ts build",
+    "start": "deno serve -A _fresh/server.js",
     "copy:assets:windows": "powershell -NoProfile -Command \"New-Item -ItemType Directory -Force build/windows | Out-Null; Copy-Item -Recurse -Force static build/windows/static; if (Test-Path games) { Copy-Item -Recurse -Force games build/windows/games }\"",
     "build:windows": "deno compile --allow-all --unstable --target x86_64-pc-windows-msvc --output build/windows/codemonkey-games-launcher.exe main.ts && deno task copy:assets:windows",
     "run:windows": "build/windows/codemonkey-games-launcher.exe",


### PR DESCRIPTION
Adds a `build` task to `deno.jsonc` and aligns the `start` and `dev` tasks with Fresh framework conventions for deployment. The new `build` task runs `deno run -A main.ts build`, which is the standard command for building a Fresh project. The `start` task is now configured to serve the production build, and the `dev` task is configured for local development with file watching.