### PR TITLE
fix: Correct macOS build script and resolve TypeScript error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bin
+dist/

--- a/desktop.ts
+++ b/desktop.ts
@@ -144,7 +144,7 @@ async function main() {
         continue;
       }
 
-      if (err.name === "AbortError") {
+    if (err instanceof Error && err.name === "AbortError") {
         break;
       }
 

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -23,14 +23,7 @@ cp "scripts/Info.plist" "${CONTENTS_DIR}/"
 
 # Compile the Deno application
 echo "Compiling Deno application..."
-deno compile \\
-  --allow-read \\
-  --allow-write \\
-  --allow-env \\
-  --allow-net \\
-  --allow-run \\
-  --output "${MACOS_DIR}/${EXECUTABLE_NAME}" \\
-  desktop.ts
+deno compile --allow-read --allow-write --allow-env --allow-net --allow-run --output "${MACOS_DIR}/${EXECUTABLE_NAME}" desktop.ts
 
 # Make the executable runnable
 chmod +x "${MACOS_DIR}/${EXECUTABLE_NAME}"


### PR DESCRIPTION
This commit addresses several issues that were preventing the macOS application from building and running correctly.

- The `deno compile` command in `scripts/build-macos.sh` has been corrected to a single line to prevent shell interpretation issues.
- A TypeScript error in `desktop.ts` related to an unknown error type has been resolved by adding a type check.
- The `dist/` directory has been added to `.gitignore` to prevent build artifacts from being committed.
- The unnecessary `install_deno.sh` script has been removed.