### PR TITLE
Fix Game Genie 404 by serving its UI inline from TS

### DIFF
--- a/lib/game-genie-html.ts
+++ b/lib/game-genie-html.ts
@@ -1,4 +1,4 @@
-<!doctype html>
+export const GAME_GENIE_HTML = String.raw`<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -253,3 +253,4 @@
   </script>
 </body>
 </html>
+`;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -90,8 +90,8 @@ const BUILTIN_GAMES: GameEntry[] = [
     id: "game-genie",
     name: "game genie",
     path: "",
-    urlPath: "/static/game-genie/",
-    launchPath: "/static/game-genie/",
+    urlPath: "/game-genie/",
+    launchPath: "/game-genie/",
     hasThumbnail: false,
   },
 ];

--- a/routes/[...path].ts
+++ b/routes/[...path].ts
@@ -2,6 +2,7 @@ import { HandlerContext, Handlers } from "$fresh/server.ts";
 import { contentType } from "https://deno.land/std@0.224.0/media_types/mod.ts";
 import { extname, join } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { GAMES_DIR, ROOT } from "../lib/utils.ts";
+import { GAME_GENIE_HTML } from "../lib/game-genie-html.ts";
 
 const injections = {
   css: `\n<style>
@@ -213,6 +214,13 @@ export const handler: Handlers = {
   async GET(req: Request, _ctx: HandlerContext) {
     const url = new URL(req.url);
     const pathname = url.pathname;
+
+    // --- Game Genie (built-in virtual game, served inline) ---
+    if (pathname === "/game-genie" || pathname === "/game-genie/" || pathname.startsWith("/game-genie/")) {
+      return new Response(GAME_GENIE_HTML, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
 
     // --- Game serving logic ---
     const serveGameFile = async (gameId: string, relPath: string, isIndex: boolean) => {


### PR DESCRIPTION
## Problem

After merging #63, the Game Genie tile appeared on the grid, but clicking it produced a "Not Found" page. Root cause: the tile's `launchPath` was `/static/game-genie/index.html`, which `routes/[...path].ts` serves from disk via `Deno.stat(join(ROOT, "static/game-genie/index.html"))`. If a user's runtime tree doesn't have that file on disk (older binary, partial rebuild, etc.), the request 404s — even though the synthetic `listGames()` entry from #63 still shows the tile.

## Fix

Move the Mods menu HTML into a TypeScript module so it lives in the compiled bundle, not as a separate asset:

- `lib/game-genie-html.ts` — single source of truth for the menu HTML.
- `routes/[...path].ts` — early-return that intercepts any `/game-genie/*` request and responds with the inlined HTML directly (`text/html`).
- `lib/utils.ts` — `BUILTIN_GAMES[0].launchPath` is now `/game-genie/` (was `/static/game-genie/`).
- `static/game-genie/index.html` — removed (now redundant; HTML lives in TS).

The Game Genie page no longer touches the filesystem at all. Works for `deno task start`, `deno task build` / preview, the compiled binary, and Deno Deploy.

## Test plan

- [ ] `git pull` master, run the launcher.
- [ ] Confirm `game genie` tile is in the grid.
- [ ] Click it → Mods menu renders (no 404), "Now playing" shows "game genie".
- [ ] Click "Enable" on the Voxel card → status pill flips to ON.
- [ ] Press Escape → back to grid. Launch mario → voxel overlay applies.
- [ ] Toggle Voxel off in Game Genie → mario launches without overlay.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xb5ozG3cmy5izR2H1MqkNn)_