### PR TITLE
Fix Voxel mod silently doing nothing by inlining its JS

### DIFF
--- a/lib/voxel-mod-js.ts
+++ b/lib/voxel-mod-js.ts
@@ -1,6 +1,8 @@
-(function () {
+export const VOXEL_MOD_JS = String.raw`(function () {
   if (window.__cmgVoxel3dInstalled) return;
   window.__cmgVoxel3dInstalled = true;
+
+  console.info('[cmg-voxel] loader running');
 
   const STORAGE_KEY = 'cmg_mod_voxel_3d';
   const THREE_URL = 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js';
@@ -24,7 +26,8 @@
   }
 
   function findGameCanvas() {
-    const candidates = Array.from(document.querySelectorAll('canvas'));
+    const candidates = Array.from(document.querySelectorAll('canvas'))
+      .filter((c) => c.id !== 'cmg-voxel-overlay');
     const visible = candidates.filter((c) => c.offsetWidth > 0 && c.offsetHeight > 0);
     const pool = visible.length ? visible : candidates;
     return pool.sort((a, b) => (a.width * a.height) - (b.width * b.height)).pop() || null;
@@ -53,6 +56,7 @@
     let THREE;
     try {
       THREE = await loadThree();
+      console.info('[cmg-voxel] three.js loaded', THREE && THREE.REVISION);
     } catch (err) {
       console.warn('[cmg-voxel] three.js failed to load', err);
       return;
@@ -63,6 +67,7 @@
       console.warn('[cmg-voxel] No source canvas found in this game');
       return;
     }
+    console.info('[cmg-voxel] source canvas', sourceCanvas.width, 'x', sourceCanvas.height);
 
     const prevSourceOpacity = sourceCanvas.style.opacity;
     sourceCanvas.style.opacity = '0';
@@ -86,12 +91,6 @@
 
     const renderer = new THREE.WebGLRenderer({ canvas: overlay, antialias: false });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
-    const setRendererSize = () => {
-      renderer.setSize(window.innerWidth, window.innerHeight, false);
-      camera.aspect = window.innerWidth / Math.max(1, window.innerHeight);
-      camera.updateProjectionMatrix();
-    };
-
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x05060d);
     scene.fog = new THREE.Fog(0x05060d, 60, 140);
@@ -100,21 +99,25 @@
     camera.position.set(0, 38, 56);
     camera.lookAt(0, 0, 0);
 
+    const setRendererSize = () => {
+      renderer.setSize(window.innerWidth, window.innerHeight, false);
+      camera.aspect = window.innerWidth / Math.max(1, window.innerHeight);
+      camera.updateProjectionMatrix();
+    };
+
     scene.add(new THREE.AmbientLight(0xffffff, 0.55));
-    const key = new THREE.DirectionalLight(0xffffff, 0.9);
-    key.position.set(20, 40, 30);
-    scene.add(key);
+    const keyLight = new THREE.DirectionalLight(0xffffff, 0.9);
+    keyLight.position.set(20, 40, 30);
+    scene.add(keyLight);
     const rim = new THREE.DirectionalLight(0x8899ff, 0.4);
     rim.position.set(-30, 20, -20);
     scene.add(rim);
 
     const geom = new THREE.BoxGeometry(CUBE_SIZE, 1, CUBE_SIZE);
-    const mat = new THREE.MeshLambertMaterial({ vertexColors: false });
+    const mat = new THREE.MeshLambertMaterial();
     const count = GRID_W * GRID_H;
     const mesh = new THREE.InstancedMesh(geom, mat, count);
     mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
-    mesh.instanceColor = new THREE.InstancedBufferAttribute(new Float32Array(count * 3), 3);
-    mesh.instanceColor.setUsage(THREE.DynamicDrawUsage);
     scene.add(mesh);
 
     const tmpObj = new THREE.Object3D();
@@ -122,10 +125,23 @@
     const offsetX = -((GRID_W - 1) * CUBE_SIZE) / 2;
     const offsetZ = -((GRID_H - 1) * CUBE_SIZE) / 2;
 
+    // Initialize all instances so they exist even before the first pixel readback.
+    for (let i = 0; i < count; i++) {
+      tmpObj.position.set(0, 0.5, 0);
+      tmpObj.scale.set(1, 1, 1);
+      tmpObj.updateMatrix();
+      mesh.setMatrixAt(i, tmpObj.matrix);
+      tmpColor.setRGB(0.5, 0.5, 0.5);
+      mesh.setColorAt(i, tmpColor);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+
     setRendererSize();
 
     let rafId = 0;
     let stopped = false;
+    let frameCount = 0;
 
     function frame() {
       if (stopped) return;
@@ -157,8 +173,10 @@
         mesh.instanceMatrix.needsUpdate = true;
         if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
         renderer.render(scene, camera);
+        if (frameCount === 0) console.info('[cmg-voxel] first frame rendered');
+        frameCount++;
       } catch (err) {
-        console.warn('[cmg-voxel] frame error', err);
+        if (frameCount < 3) console.warn('[cmg-voxel] frame error', err);
       }
       rafId = requestAnimationFrame(frame);
     }
@@ -196,3 +214,4 @@
     install();
   }
 })();
+`;

--- a/routes/[...path].ts
+++ b/routes/[...path].ts
@@ -3,6 +3,7 @@ import { contentType } from "https://deno.land/std@0.224.0/media_types/mod.ts";
 import { extname, join } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { GAMES_DIR, ROOT } from "../lib/utils.ts";
 import { GAME_GENIE_HTML } from "../lib/game-genie-html.ts";
+import { VOXEL_MOD_JS } from "../lib/voxel-mod-js.ts";
 
 const injections = {
   css: `\n<style>
@@ -108,7 +109,7 @@ const injections = {
         if (document.getElementById('cmg-mod-voxel-3d')) return;
         var s = document.createElement('script');
         s.id = 'cmg-mod-voxel-3d';
-        s.src = '/static/mods/voxel-3d.js';
+        s.src = '/mods/voxel-3d.js';
         s.defer = true;
         (document.head || document.documentElement).appendChild(s);
       }
@@ -219,6 +220,13 @@ export const handler: Handlers = {
     if (pathname === "/game-genie" || pathname === "/game-genie/" || pathname.startsWith("/game-genie/")) {
       return new Response(GAME_GENIE_HTML, {
         headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    // --- Voxel mod script (served inline so it doesn't depend on disk assets) ---
+    if (pathname === "/mods/voxel-3d.js") {
+      return new Response(VOXEL_MOD_JS, {
+        headers: { "content-type": "text/javascript; charset=utf-8" },
       });
     }
 


### PR DESCRIPTION
## Problem

Toggling **2D → 3D Voxel** in Game Genie had no visual effect when launching a game. Most likely cause: the loader injection in `routes/[...path].ts` points at `/static/mods/voxel-3d.js`, which gets served from disk by the static-asset path. If the user's runtime tree doesn't have that file on disk (older binary, partial rebuild, deploy without static assets), the script silently 404s and the toggle appears to do nothing.

Same fragility class as the Game Genie 404 fixed in #64 — and the same fix.

## Fix

- `lib/voxel-mod-js.ts` — single source of truth for the mod's JS (exported as a string).
- `routes/[...path].ts` — intercept `/mods/voxel-3d.js` and respond with the inlined script (`text/javascript`). The injection's `s.src` is now `/mods/voxel-3d.js` (no `/static/` prefix).
- `static/mods/voxel-3d.js` — removed (redundant).

### Diagnostic improvements

Also added `console.info` logs (`[cmg-voxel] loader running`, `three.js loaded <revision>`, `source canvas <w>x<h>`, `first frame rendered`) so the toggle's runtime status is visible in DevTools, plus:

- The `InstancedMesh` matrices/colors are pre-seeded so nothing renders empty for one frame.
- `findGameCanvas()` excludes the voxel overlay itself by id, so quick toggle/reload cycles can't accidentally pick the overlay as the source.

## Test plan

- [ ] `git pull` master, run the launcher.
- [ ] Open Game Genie tile, click **Enable** on **2D → 3D Voxel** → status pill flips to ON.
- [ ] Press Escape, launch `mario`. Open DevTools console — should see:
  - `[cmg-voxel] loader running`
  - `[cmg-voxel] three.js loaded 160`
  - `[cmg-voxel] source canvas <w>x<h>`
  - `[cmg-voxel] first frame rendered`
  - The screen should show a tilted field of cubes whose colors/heights track the game's pixels.
- [ ] Exit, toggle off in Game Genie, relaunch `mario` → game renders normally (overlay torn down).
- [ ] Repeat with `akuma` (WebGL game) — voxel overlay should also apply with no CORS errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xb5ozG3cmy5izR2H1MqkNn)_