### PR TITLE
Fix injections never running for explicit index.html game requests

### DIFF
--- a/routes/[...path].ts
+++ b/routes/[...path].ts
@@ -284,6 +284,12 @@ export const handler: Handlers = {
       return new Response("Not Found", { status: 404 });
     }
 
+    const isHtmlEntry = (relPath: string, urlPath: string) => {
+      if (relPath === "" || urlPath.endsWith("/")) return true;
+      const lower = relPath.toLowerCase();
+      return lower.endsWith(".html") || lower.endsWith(".htm");
+    };
+
     // --- Game alias routing: /<gameId>/... -> /games/<gameId>/...
     const segs = pathname.replace(/^\/+/, "").split("/");
     const firstSeg = segs[0] || "";
@@ -293,8 +299,9 @@ export const handler: Handlers = {
         const st = await Deno.stat(join(GAMES_DIR, firstSeg));
         if (st.isDirectory) {
           const relPath = segs.slice(1).join("/");
-          const isIndex = relPath === "" || pathname.endsWith("/");
-          return await serveGameFile(firstSeg, isIndex ? "index.html" : relPath, isIndex);
+          const isIndex = isHtmlEntry(relPath, pathname);
+          const fileToServe = relPath === "" || pathname.endsWith("/") ? "index.html" : relPath;
+          return await serveGameFile(firstSeg, fileToServe, isIndex);
         }
       } catch { /* not a game folder */ }
     }
@@ -309,8 +316,9 @@ export const handler: Handlers = {
           const st = await Deno.stat(join(GAMES_DIR, gameId));
           if (st.isDirectory) {
             const relPath = segs.slice(1).join("/");
-            const isIndex = relPath === "" || pathname.endsWith("/");
-            return await serveGameFile(gameId, isIndex ? "index.html" : relPath, isIndex);
+            const isIndex = isHtmlEntry(relPath, pathname);
+            const fileToServe = relPath === "" || pathname.endsWith("/") ? "index.html" : relPath;
+            return await serveGameFile(gameId, fileToServe, isIndex);
           }
         } catch { /* not a game folder */ }
       }


### PR DESCRIPTION
## Problem

Toggling **2D → 3D Voxel** in Game Genie still produced no visual effect, with no `[cmg-voxel]` console log and no network request for `/mods/voxel-3d.js`. The loader script was never even being put into the served HTML.

## Root cause

The injection pipeline in `routes/[...path].ts` decides whether to inject (`voxelMod`, `osd`, `cursorToggle`, `screenshotPreserve`, `marker`, etc.) based on an `isIndex` flag. That flag was only `true` when the URL ended with `/` or pointed at a bare directory:

```ts
const isIndex = relPath === "" || pathname.endsWith("/");
```

But `static/main.js:openGame()` always builds an explicit URL:

```js
const target = basePath.endsWith('/') ? `${basePath}index.html` : `${basePath}/index.html`;
gameframe.src = target;
```

So every game launch hit `/games/<id>/index.html`, which has `isIndex === false`, and **no injections were ever applied** to actually-launched games. Existing features kept working because `static/main.js:bindIframeKeys()` attaches the OSD/cursor logic directly from the parent (same-origin) — the voxel mod has no such parent-side fallback.

Console evidence from the user: mario launched, all of its own assets fetched fine, but no `/mods/voxel-3d.js` request, no `[cmg-voxel]` logs. Also: `This page is in Quirks Mode` — because the missing injection means the served HTML wasn't being touched at all.

## Fix

Extend `isIndex` so it's also true for explicit `*.html` / `*.htm` requests inside a game folder, in both the `/games/<id>/...` route and the `/<gameId>/...` alias route. Trailing-slash directory requests keep behaving the same (serve `index.html`). Other (non-HTML) game assets are unaffected.

```ts
const isHtmlEntry = (relPath, urlPath) => {
  if (relPath === "" || urlPath.endsWith("/")) return true;
  const lower = relPath.toLowerCase();
  return lower.endsWith(".html") || lower.endsWith(".htm");
};
```

## Test plan

- [ ] `git pull` master, restart the launcher.
- [ ] Game Genie → enable **2D → 3D Voxel**.
- [ ] Launch `mario`. Open DevTools console; you should see:
  - `[cmg-voxel] loader running`
  - `[cmg-voxel] three.js loaded 160`
  - `[cmg-voxel] source canvas <w>x<h>`
  - `[cmg-voxel] first frame rendered`
- [ ] A tilted field of cubes whose colors/heights track the game's pixels appears.
- [ ] Toggle off in Game Genie, relaunch mario → normal rendering.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xb5ozG3cmy5izR2H1MqkNn)_